### PR TITLE
Adjust canvas size and camera height

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,11 @@ import { BulletProvider } from './hooks/useBullets.jsx';
 
 export default function App() {
   return (
-    <Canvas shadows camera={{ fov: 75 }}>
+    <Canvas
+      shadows
+      camera={{ fov: 75, position: [0, 1, 0] }}
+      style={{ width: '100%', height: '100%' }}
+    >
       <Suspense fallback={null}>
         <BulletProvider>
           <color attach="background" args={[0.6, 0.7, 0.9]} />

--- a/src/components/Player.jsx
+++ b/src/components/Player.jsx
@@ -10,6 +10,11 @@ export default function Player() {
   const keys = usePlayerControls();
   const { shoot } = useBullets();
 
+  // Set initial camera height for a more natural viewpoint
+  useEffect(() => {
+    camera.position.y = 1;
+  }, [camera]);
+
   useFrame((state, delta) => {
     if (!controlsRef.current?.isLocked) return;
     const speed = 5;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,10 @@
+html, body, #root {
+  margin: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+canvas {
+  display: block;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.jsx';
+import './index.css';
 
 const root = createRoot(document.getElementById('root'));
 root.render(<App />);


### PR DESCRIPTION
## Summary
- make the canvas stretch to the whole viewport with global CSS
- ensure the camera starts at eye level
- size the Canvas element for full-screen rendering

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68641b9b70f4832cb217a9c1951eccf8