### PR TITLE
Add mobile touch controls

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Canvas } from '@react-three/fiber';
 import { Suspense } from 'react';
+import { Html } from '@react-three/drei';
+import TouchControls from './components/TouchControls.jsx';
 import Environment from './components/Environment.jsx';
 import Player from './components/Player.jsx';
 import Gun from './components/Gun.jsx';
@@ -23,6 +25,9 @@ export default function App() {
           <Player />
           <Gun />
           <Bullets />
+          <Html fullscreen>
+            <TouchControls />
+          </Html>
         </BulletProvider>
       </Suspense>
     </Canvas>

--- a/src/components/TouchControls.jsx
+++ b/src/components/TouchControls.jsx
@@ -1,0 +1,74 @@
+import React, { useRef, useState } from 'react';
+import { useBullets } from '../hooks/useBullets.jsx';
+
+const keyMap = {
+  forward: 'KeyW',
+  backward: 'KeyS',
+  left: 'KeyA',
+  right: 'KeyD',
+};
+
+export default function TouchControls() {
+  const { shoot } = useBullets();
+  const joyRef = useRef();
+  const stickRef = useRef();
+  const [state, setState] = useState({});
+
+  const threshold = 15; // pixels
+
+  const dispatch = (code, type) => {
+    window.dispatchEvent(new KeyboardEvent(type, { code }));
+  };
+
+  const updateDir = (next) => {
+    Object.keys(keyMap).forEach((dir) => {
+      if (next[dir] !== state[dir]) {
+        dispatch(keyMap[dir], next[dir] ? 'keydown' : 'keyup');
+      }
+    });
+    setState(next);
+  };
+
+  const handleMove = (e) => {
+    const touch = e.touches[0];
+    if (!touch || !joyRef.current) return;
+    const rect = joyRef.current.getBoundingClientRect();
+    const x = touch.clientX - rect.left - rect.width / 2;
+    const y = touch.clientY - rect.top - rect.height / 2;
+    stickRef.current.style.transform = `translate(${x}px, ${y}px)`;
+    const next = {
+      forward: y < -threshold,
+      backward: y > threshold,
+      left: x < -threshold,
+      right: x > threshold,
+    };
+    updateDir(next);
+  };
+
+  const reset = () => {
+    if (stickRef.current) stickRef.current.style.transform = 'translate(0px, 0px)';
+    updateDir({ forward: false, backward: false, left: false, right: false });
+  };
+
+  return (
+    <>
+      <div
+        className="joystick"
+        ref={joyRef}
+        onTouchStart={handleMove}
+        onTouchMove={handleMove}
+        onTouchEnd={reset}
+        onTouchCancel={reset}
+      >
+        <div className="stick" ref={stickRef} />
+      </div>
+      <div
+        className="fire-btn"
+        onTouchStart={(e) => {
+          e.preventDefault();
+          shoot();
+        }}
+      />
+    </>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -8,3 +8,39 @@ html, body, #root {
 canvas {
   display: block;
 }
+
+.joystick {
+  position: absolute;
+  left: 20px;
+  bottom: 20px;
+  width: 100px;
+  height: 100px;
+  border: 2px solid rgba(255, 255, 255, 0.5);
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.1);
+  touch-action: none;
+}
+
+.joystick .stick {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 40px;
+  height: 40px;
+  margin-left: -20px;
+  margin-top: -20px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.6);
+}
+
+.fire-btn {
+  position: absolute;
+  right: 20px;
+  bottom: 40px;
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.8);
+  background: rgba(255, 255, 255, 0.3);
+  touch-action: none;
+}


### PR DESCRIPTION
## Summary
- overlay touch joystick and fire button
- dispatch virtual key events for movement and call shoot handler
- style controls in CSS

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686426331800832ca3e7b23e69ea8fed